### PR TITLE
feat: add option to pass list of allowed commit types

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -29,5 +29,3 @@ jobs:
       
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest
-        with:
-          types: "fix,chore"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest
         with:
-          types: "fix,feat,chore"
+          types: "fix,chore"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -29,3 +29,5 @@ jobs:
       
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest
+        with:
+          types: "fix,feat,chore"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ feat(client): add component
 
 The action can be used with both the `pull_request` and `pull_request_target` trigger.
 
+`default`
 ```yaml
 name: validate-pull-request-title
 
@@ -36,5 +37,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.1.0
+        uses: kontrolplane/pull-request-title-validator@v1.2.0
+```
+
+`custom types`
+```yaml
+name: validate-pull-request-title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validator:
+    name: validate-pull-request-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: validate pull request title
+        uses: kontrolplane/pull-request-title-validator@v1.2.0
+        with:
+          types: "fix,feat,chore"
 ```

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 var desiredFormat string = "<type>(optional: <scope>): <message>"
+var defaultConventionTypes []string = []string{"fix", "feat", "chore", "docs", "build", "ci", "refactor", "perf", "test"}
 
 type PullRequest struct {
 	Title string `json:"title"`
@@ -23,7 +24,7 @@ type Event struct {
 func main() {
 	githubEventName := os.Getenv("GITHUB_EVENT_NAME")
 	githubEventPath := os.Getenv("GITHUB_EVENT_PATH")
-	conventionTypes := []string{"fix", "feat", "chore", "docs", "build", "ci", "refactor", "perf", "test"}
+	conventionTypes := parseTypes(os.Getenv("INPUT_TYPES"), defaultConventionTypes)
 
 	if githubEventName != "pull_request" && githubEventName != "pull_request_target" {
 		fmt.Printf("Error: the 'pull_request' trigger type should be used, received '%s'\n", githubEventName)
@@ -103,4 +104,18 @@ func checkAgainstConventionTypes(titleType string, conventionTypes []string) err
 	}
 
 	return fmt.Errorf("the type passed '%s' is not present in the types allowed by the convention: %s", titleType, conventionTypes)
+}
+
+func parseTypes(input string, fallback []string) []string {
+	if input == "" {
+		return fallback
+	}
+	types := strings.Split(input, ",")
+	for i := range types {
+		types[i] = strings.TrimSpace(types[i])
+	}
+	if len(types) == 0 {
+		return fallback
+	}
+	return types
 }

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func splitTitle(title string) (titleType string, titleScope string, titleMessage
 		titleMessage = strings.SplitAfter(title, ":")[1]
 		titleMessage = strings.TrimSpace(titleMessage)
 	} else {
-		fmt.Println("No message was included in the pull request title.")
+		fmt.Println("no message was included in the pull request title.")
 		fmt.Println(desiredFormat)
 		os.Exit(1)
 	}
@@ -108,6 +108,7 @@ func checkAgainstConventionTypes(titleType string, conventionTypes []string) err
 
 func parseTypes(input string, fallback []string) []string {
 	if input == "" {
+		fmt.Println("no custom list of commit types was passed using fallback.")
 		return fallback
 	}
 	types := strings.Split(input, ",")


### PR DESCRIPTION
this pull request introduces the option to pass a custom list of commit types as desired, passing no types via `with.types` will default to the standard of conventional commits.