### PR TITLE
feat: support prefix based parsing for scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ feat(client): add component
 
 The action can be used with both the `pull_request` and `pull_request_target` trigger.
 
-`default`
+### Default
 
 ```yaml
 name: validate-pull-request-title
@@ -41,7 +41,7 @@ jobs:
         uses: kontrolplane/pull-request-title-validator@v1.2.0
 ```
 
-`custom types`
+### Custom types
 
 ```yaml
 name: validate-pull-request-title
@@ -67,7 +67,9 @@ jobs:
           types: "fix,feat,chore"
 ```
 
-`custom scopes`
+### Custom scopes
+
+Scopes support regular expression patterns, allowing you to define specific patterns to match the scopes you want to allow. You can also separate multiple scopes using commas.
 
 ```yaml
 name: validate-pull-request-title
@@ -88,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.2.0
+        uses: kontrolplane/pull-request-title-validator@v1.4.0
         with:
-          scopes: "api,lang,parser"
+          scopes: "api,lang,parser,package/.+"
 ```

--- a/main.go
+++ b/main.go
@@ -114,12 +114,12 @@ func checkAgainstConventionTypes(titleType string, conventionTypes []string) err
 
 func checkAgainstScopes(titleScope string, scopes []string) error {
 	for _, scope := range scopes {
-		if titleScope == scope {
+		if regexp.MustCompile("(?i)" + scope + "$").MatchString(titleScope) {
 			return nil
 		}
 	}
 
-	return fmt.Errorf("the scope '%s' is not allowed. Please choose from the following scopes: %s", titleScope, scopes)
+	return fmt.Errorf("the scope '%s' is not allowed. Please choose from the following patterns of scopes: %s", titleScope, scopes)
 }
 
 func parseTypes(input string, fallback []string) []string {

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := checkAgainstScopes(titleScope, scopes); err != nil && len(scopes) > 1 {
+	if err := checkAgainstScopes(titleScope, scopes); err != nil && len(scopes) >= 1 {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Hi @levivannoort, this PR addresses the prefix-based parsing for scopes, implementing regex pattern support. It also updates the scope-checking conditions to ensure the workflow functions correctly even with a single scope. If you have any feedback or suggestions, please let me know. Thanks!