### PR TITLE
chore: change environment variable parsing and logging

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,10 +19,5 @@ jobs:
         with:
           go-version: 1.23.1
 
-      - name: run linters
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.53
-
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,5 +19,10 @@ jobs:
         with:
           go-version: 1.23.1
 
+      - name: run linters
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53
+
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.23.1
 
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,13 +19,5 @@ jobs:
         with:
           go-version: 1.21.3
 
-      - name: run linters
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.53
-
-      - name: checkout code
-        uses: actions/checkout@v4
-      
       - name: pull request title validator
         uses: ./ # kontrolplane/pull-request-title-validator@latest

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -1,0 +1,35 @@
+name: update-contributors
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  update-contributors:
+    name: validate-pull-request-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: update-contributors
+        uses: kontrolplane/generate-contributors-list@v1.0.0
+        with:
+          owner: kontrolplane
+          repository: pull-request-title-validator
+
+      - name: open-pull-request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add README.md
+          git commit -m "chore: update contributors section"
+          git push -u origin update-contributors
+          gh pr create \
+            --title "chore: update contributors" \
+            --body "Automatically update contributors section." \
+            --base main \
+            --head update-contributors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 AS build
+FROM golang:1.23.1 AS build
 WORKDIR /action
 COPY . .
 RUN CGO_ENABLED=0 go build -o pull-request-title-validator

--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ jobs:
         with:
           types: "fix,feat,chore"
 ```
+
+
+## contributors
+
+[//]: kontrolplane/generate-contributors-list
+
+[//]: kontrolplane/generate-contributors-list

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
           scopes: "api,lang,parser,package/.+"
 ```
 
-## contributors
+## Contributors
 
 [//]: kontrolplane/generate-contributors-list
 

--- a/README.md
+++ b/README.md
@@ -99,4 +99,7 @@ jobs:
 
 [//]: kontrolplane/generate-contributors-list
 
+<a href="https://github.com/levivannoort"><img src="https://avatars.githubusercontent.com/u/73097785?v=4" title="levivannoort" width="50" height="50"></a>
+<a href="https://github.com/paopa"><img src="https://avatars.githubusercontent.com/u/52045032?v=4" title="paopa" width="50" height="50"></a>
+
 [//]: kontrolplane/generate-contributors-list

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/kontrolplane/pull-request-title-validator
 
 go 1.21.1
+
+require (
+	github.com/caarlos0/env v3.5.0+incompatible // indirect
+	github.com/caarlos0/env/v11 v11.2.2 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/kontrolplane/pull-request-title-validator
 
-go 1.21.1
+go 1.23.1
 
-require (
-	github.com/caarlos0/env v3.5.0+incompatible // indirect
-	github.com/caarlos0/env/v11 v11.2.2 // indirect
-)
+require github.com/caarlos0/env v3.5.0+incompatible
+
+require github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
+github.com/caarlos0/env/v11 v11.2.2 h1:95fApNrUyueipoZN/EhA8mMxiNxrBwDa+oAZrMWl3Kg=
+github.com/caarlos0/env/v11 v11.2.2/go.mod h1:JBfcdeQiBoI3Zh1QRAWfe+tpiNTmDtcCj/hHHHMx0vc=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
 github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
 github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
-github.com/caarlos0/env/v11 v11.2.2 h1:95fApNrUyueipoZN/EhA8mMxiNxrBwDa+oAZrMWl3Kg=
-github.com/caarlos0/env/v11 v11.2.2/go.mod h1:JBfcdeQiBoI3Zh1QRAWfe+tpiNTmDtcCj/hHHHMx0vc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -6,10 +6,21 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"log/slog"
+
+	"github.com/caarlos0/env"
 )
 
 var desiredFormat string = "<type>(optional: <scope>): <message>"
 var defaultConventionTypes []string = []string{"fix", "feat", "chore", "docs", "build", "ci", "refactor", "perf", "test"}
+
+type config struct {
+	githubEventName string `env:"GITHUB_EVENT_NAME"`
+	githubEventPath string `env:"GITHUB_EVENT_PATH"`
+	types           string `env:"INPUT_TYPES"`
+	scope           string `env:"INPUT_SCOPE"`
+}
 
 type PullRequest struct {
 	Title string `json:"title"`
@@ -22,101 +33,139 @@ type Event struct {
 // The pull-request-title-validator function mankes sure that for each pull request created the
 // title of the pull request adheres to a desired structure, in this case convention commit style.
 func main() {
-	githubEventName := os.Getenv("GITHUB_EVENT_NAME")
-	githubEventPath := os.Getenv("GITHUB_EVENT_PATH")
-	conventionTypes := parseTypes(os.Getenv("INPUT_TYPES"), defaultConventionTypes)
 
-	if githubEventName != "pull_request" && githubEventName != "pull_request_target" {
-		fmt.Printf("Error: the 'pull_request' trigger type should be used, received '%s'\n", githubEventName)
+	var cfg config
+	if err := env.Parse(&cfg); err != nil {
+		fmt.Printf("unable to parse the environment variables: %v", err)
 		os.Exit(1)
 	}
 
-	title := fetchTitle(githubEventPath)
-	titleType, titleScope, titleMessage := splitTitle(title)
+	logHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: false,
+		Level:     slog.LevelInfo,
+	})
+	logger := slog.New(logHandler)
 
-	if err := checkAgainstConventionTypes(titleType, conventionTypes); err != nil {
-		fmt.Printf("The type passed '%s' is not present in the types allowed by the convention: %s\n", titleType, conventionTypes)
+	logger.Info("starting pull-request-title-validator", slog.String("event", cfg.githubEventName))
+
+	if cfg.githubEventName != "pull_request" && cfg.githubEventName != "pull_request_target" {
+		logger.Error("invalid event type", slog.String("event", cfg.githubEventName))
 		os.Exit(1)
 	}
 
-	fmt.Printf("commit title type used: %s\n", titleType)
-	fmt.Printf("commit title scope used: %s\n", titleScope)
-	fmt.Printf("commit title message used: %s\n\n", titleMessage)
-	fmt.Printf("the commit message adheres to the configured standard")
+	title := fetchTitle(logger, cfg.githubEventPath)
+	titleType, titleScope, titleMessage := splitTitle(logger, title)
+
+	parsedTypes := parseTypes(logger, cfg.types, defaultConventionTypes)
+	parsedScope := parseScopes(logger, cfg.scope)
+
+	if err := checkAgainstConventionTypes(logger, titleType, parsedTypes); err != nil {
+		logger.Error("error while checking the type against the allowed types",
+			slog.String("input", cfg.githubEventName),
+			slog.Any("conventionTypes", parsedTypes),
+		)
+		os.Exit(1)
+	}
+
+	if err := checkAgainstScopes(logger, titleScope, parsedScope); err != nil && len(parsedScope) >= 1 {
+		logger.Error("error while checking the scope against the allowed scopes", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	logger.Info("commit title validated successfully",
+		slog.String("type", titleType),
+		slog.String("scope", titleScope),
+		slog.String("message", titleMessage),
+	)
+	logger.Info("the commit message adheres to the configured standard")
 }
 
-func fetchTitle(githubEventPath string) string {
-
+func fetchTitle(logger *slog.Logger, githubEventPath string) string {
 	var event Event
 	var eventData []byte
 	var err error
 
 	if eventData, err = os.ReadFile(githubEventPath); err != nil {
-		fmt.Printf("Problem reading the event json file: %v\n", err)
-		os.Exit(1)
+		logger.Error("Problem reading the event JSON file", slog.String("path", githubEventPath), slog.Any("error", err))
+		os.Exit(1) // You might want to return an empty string or handle this error upstream instead.
 	}
 
 	if err = json.Unmarshal(eventData, &event); err != nil {
-		fmt.Printf("Failed to unmarshal JSON: %v", err)
+		logger.Error("Failed to unmarshal JSON", slog.Any("error", err))
 		os.Exit(1)
 	}
 
 	return event.PullRequest.Title
 }
 
-func splitTitle(title string) (titleType string, titleScope string, titleMessage string) {
-
-	// this part of the function extracts the type
+func splitTitle(logger *slog.Logger, title string) (titleType string, titleScope string, titleMessage string) {
 	if index := strings.Index(title, "("); strings.Contains(title, "(") {
 		titleType = title[:index]
 	} else if index := strings.Index(title, ":"); strings.Contains(title, ":") {
 		titleType = title[:index]
 	} else {
-		fmt.Println("No type was included in the pull request title.")
-		fmt.Println(desiredFormat)
+		logger.Error("No type was included in the pull request title.")
 		os.Exit(1)
 	}
 
-	// this part of the function extracts the optional scope
 	if strings.Contains(title, "(") && strings.Contains(title, ")") {
 		scope := regexp.MustCompile(`\(([^)]+)\)`)
-		titleScope = scope.FindStringSubmatch(title)[1]
+		if matches := scope.FindStringSubmatch(title); len(matches) > 1 {
+			titleScope = matches[1]
+		}
 	}
 
-	// this part of the function extracts the message
 	if strings.Contains(title, ":") {
 		titleMessage = strings.SplitAfter(title, ":")[1]
 		titleMessage = strings.TrimSpace(titleMessage)
 	} else {
-		fmt.Println("no message was included in the pull request title.")
-		fmt.Println(desiredFormat)
+		logger.Error("No message was included in the pull request title.")
 		os.Exit(1)
 	}
 
 	return
 }
 
-func checkAgainstConventionTypes(titleType string, conventionTypes []string) error {
+func checkAgainstConventionTypes(logger *slog.Logger, titleType string, conventionTypes []string) error {
 	for _, conventionType := range conventionTypes {
 		if titleType == conventionType {
 			return nil
 		}
 	}
-
-	return fmt.Errorf("the type passed '%s' is not present in the types allowed by the convention: %s", titleType, conventionTypes)
+	logger.Error("Type not allowed by the convention", slog.String("type", titleType), slog.Any("allowedTypes", conventionTypes))
+	return fmt.Errorf("type '%s' is not allowed", titleType)
 }
 
-func parseTypes(input string, fallback []string) []string {
+func checkAgainstScopes(logger *slog.Logger, titleScope string, scopes []string) error {
+	for _, scope := range scopes {
+		if regexp.MustCompile("(?i)" + scope + "$").MatchString(titleScope) {
+			return nil
+		}
+	}
+	logger.Error("Scope not allowed", slog.String("scope", titleScope), slog.Any("allowedScopes", scopes))
+	return fmt.Errorf("scope '%s' is not allowed", titleScope)
+}
+
+func parseTypes(logger *slog.Logger, input string, fallback []string) []string {
 	if input == "" {
-		fmt.Println("no custom list of commit types was passed using fallback.")
+		logger.Warn("No custom list of commit types passed, using fallback.")
 		return fallback
 	}
 	types := strings.Split(input, ",")
 	for i := range types {
 		types[i] = strings.TrimSpace(types[i])
 	}
-	if len(types) == 0 {
-		return fallback
-	}
 	return types
+}
+
+func parseScopes(logger *slog.Logger, input string) []string {
+	if input == "" {
+		logger.Warn("No custom list of commit scopes passed, using fallback.")
+		return []string{}
+	}
+	scopes := strings.Split(input, ",")
+	for i := range scopes {
+		scopes[i] = strings.TrimSpace(scopes[i])
+	}
+	return scopes
 }

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func checkAgainstScopes(logger *slog.Logger, titleScope string, scopes []string)
 			return nil
 		}
 	}
-	logger.Error("Scope not allowed", slog.String("scope", titleScope), slog.Any("allowedScopes", scopes))
+
 	return fmt.Errorf("scope '%s' is not allowed", titleScope)
 }
 
@@ -152,10 +152,12 @@ func parseTypes(logger *slog.Logger, input string, fallback []string) []string {
 		logger.Warn("No custom list of commit types passed, using fallback.")
 		return fallback
 	}
+
 	types := strings.Split(input, ",")
 	for i := range types {
 		types[i] = strings.TrimSpace(types[i])
 	}
+
 	return types
 }
 
@@ -164,9 +166,11 @@ func parseScopes(logger *slog.Logger, input string) []string {
 		logger.Warn("No custom list of commit scopes passed, using fallback.")
 		return []string{}
 	}
+
 	scopes := strings.Split(input, ",")
 	for i := range scopes {
 		scopes[i] = strings.TrimSpace(scopes[i])
 	}
+
 	return scopes
 }

--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ var desiredFormat string = "<type>(optional: <scope>): <message>"
 var defaultConventionTypes []string = []string{"fix", "feat", "chore", "docs", "build", "ci", "refactor", "perf", "test"}
 
 type config struct {
-	githubEventName string `env:"GITHUB_EVENT_NAME"`
-	githubEventPath string `env:"GITHUB_EVENT_PATH"`
-	types           string `env:"INPUT_TYPES"`
-	scope           string `env:"INPUT_SCOPE"`
+	GithubEventName string `env:"GITHUB_EVENT_NAME"`
+	GithubEventPath string `env:"GITHUB_EVENT_PATH"`
+	Types           string `env:"INPUT_TYPES"`
+	Scope           string `env:"INPUT_SCOPE"`
 }
 
 type PullRequest struct {
@@ -46,23 +46,24 @@ func main() {
 	})
 	logger := slog.New(logHandler)
 
-	logger.Info("starting pull-request-title-validator", slog.String("event", cfg.githubEventName))
+	logger.Info("starting pull-request-title-validator", slog.String("event", cfg.GithubEventName))
 
-	if cfg.githubEventName != "pull_request" && cfg.githubEventName != "pull_request_target" {
-		logger.Error("invalid event type", slog.String("event", cfg.githubEventName))
+	if cfg.GithubEventName != "pull_request" && cfg.GithubEventName != "pull_request_target" {
+		logger.Error("invalid event type", slog.String("event", cfg.GithubEventName))
 		os.Exit(1)
 	}
 
-	title := fetchTitle(logger, cfg.githubEventPath)
+	title := fetchTitle(logger, cfg.GithubEventPath)
 	titleType, titleScope, titleMessage := splitTitle(logger, title)
 
-	parsedTypes := parseTypes(logger, cfg.types, defaultConventionTypes)
-	parsedScope := parseScopes(logger, cfg.scope)
+	parsedTypes := parseTypes(logger, cfg.Types, defaultConventionTypes)
+	parsedScope := parseScopes(logger, cfg.Scope)
 
 	if err := checkAgainstConventionTypes(logger, titleType, parsedTypes); err != nil {
 		logger.Error("error while checking the type against the allowed types",
-			slog.String("input", cfg.githubEventName),
-			slog.Any("conventionTypes", parsedTypes),
+			slog.String("event name", cfg.GithubEventName),
+			slog.String("event path", cfg.GithubEventPath),
+			slog.Any("convention types", parsedTypes),
 		)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func splitTitle(logger *slog.Logger, title string) (titleType string, titleScope
 	} else if index := strings.Index(title, ":"); strings.Contains(title, ":") {
 		titleType = title[:index]
 	} else {
-		logger.Error("No type was included in the pull request title.")
+		logger.Error("No type was included in the pull request title.", slog.String("desired format", desiredFormat))
 		os.Exit(1)
 	}
 
@@ -119,7 +119,7 @@ func splitTitle(logger *slog.Logger, title string) (titleType string, titleScope
 		titleMessage = strings.SplitAfter(title, ":")[1]
 		titleMessage = strings.TrimSpace(titleMessage)
 	} else {
-		logger.Error("No message was included in the pull request title.")
+		logger.Error("No message was included in the pull request title.", slog.String("desired format", desiredFormat))
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This pull request contains changes for moving over for the parsing of the environment variables, where a tool is used to map it to a struct. Also the logging has been moved to structured logging using `slog`. Lastly a pipeline has been introduced which auto generates contributions to the `readme.md`