### PR TITLE
fix: correct scopes input env var typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.4.1
+        uses: kontrolplane/pull-request-title-validator@v1.4.2
 ```
 
 ### Custom types
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.4.1
+        uses: kontrolplane/pull-request-title-validator@v1.4.2
         with:
           types: "fix,feat,chore"
 ```
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate pull request title
-        uses: kontrolplane/pull-request-title-validator@v1.4.1
+        uses: kontrolplane/pull-request-title-validator@v1.4.2
         with:
           scopes: "api,lang,parser,package/.+"
 ```
@@ -101,5 +101,7 @@ jobs:
 
 <a href="https://github.com/levivannoort"><img src="https://avatars.githubusercontent.com/u/73097785?v=4" title="levivannoort" width="50" height="50"></a>
 <a href="https://github.com/paopa"><img src="https://avatars.githubusercontent.com/u/52045032?v=4" title="paopa" width="50" height="50"></a>
+<a href="https://github.com/jlenuffpdna"><img src="https://avatars.githubusercontent.com/u/196163324?v=4" title="jlenuffpdna" width="50" height="50"></a>
+
 
 [//]: kontrolplane/generate-contributors-list

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type config struct {
 	GithubEventName string `env:"GITHUB_EVENT_NAME"`
 	GithubEventPath string `env:"GITHUB_EVENT_PATH"`
 	Types           string `env:"INPUT_TYPES"`
-	Scope           string `env:"INPUT_SCOPES"`
+	Scopes          string `env:"INPUT_SCOPES"`
 }
 
 type PullRequest struct {
@@ -57,7 +57,7 @@ func main() {
 	titleType, titleScope, titleMessage := splitTitle(logger, title)
 
 	parsedTypes := parseTypes(logger, cfg.Types, defaultConventionTypes)
-	parsedScope := parseScopes(logger, cfg.Scope)
+	parsedScopes := parseScopes(logger, cfg.Scopes)
 
 	if err := checkAgainstConventionTypes(logger, titleType, parsedTypes); err != nil {
 		logger.Error("error while checking the type against the allowed types",
@@ -68,7 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := checkAgainstScopes(logger, titleScope, parsedScope); err != nil && len(parsedScope) >= 1 {
+	if err := checkAgainstScopes(logger, titleScope, parsedScopes); err != nil && len(parsedScopes) >= 1 {
 		logger.Error("error while checking the scope against the allowed scopes", slog.Any("error", err))
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type config struct {
 	GithubEventName string `env:"GITHUB_EVENT_NAME"`
 	GithubEventPath string `env:"GITHUB_EVENT_PATH"`
 	Types           string `env:"INPUT_TYPES"`
-	Scope           string `env:"INPUT_SCOPE"`
+	Scope           string `env:"INPUT_SCOPES"`
 }
 
 type PullRequest struct {


### PR DESCRIPTION
Correct typo in scopes input env var